### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "astar-typescript",
+  "version": "1.1.8",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "dist/astar.js",
   "types": "dist/astar.d.ts",
   "scripts": {
+    "prepare": "tsc",
     "build": "tsc",
     "run-example": "cd example && yarn install && yarn run dev"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "declaration": true,
     "outDir": "./dist",
     "strict": false
-  }
+  },
+  "exclude": ["example/*", "dist/*"]
 }
-
-


### PR DESCRIPTION
This PR

- Fixes failing builds with a fresh install (no node_modules or dist) as the tsc command tries to build everything in example and dist folder and fails.
- Commits package lock, this is recommended to keep everyone in version sync.
- Adds prepare script to fix the missing dist folder on the npm module.