### PR TITLE
Use lodash-es instead of lodash

### DIFF
--- a/lib/finders/astar-finder.ts
+++ b/lib/finders/astar-finder.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import { minBy, remove } from 'lodash-es';
 
 import { backtrace } from '../core/util';
 import { calculateHeuristic } from '../core/heuristic';
@@ -112,13 +112,13 @@ export class AStarFinder {
     // As long the open list is not empty, continue searching a path
     while (this.openList.length !== 0) {
       // Get node with lowest f value
-      const currentNode = _.minBy(this.openList, (o) => {
+      const currentNode = minBy(this.openList, (o) => {
         return o.getFValue();
       });
 
       // Move current node from open list to closed list
       currentNode.setIsOnOpenList(false);
-      _.remove(this.openList, currentNode);
+      remove(this.openList, currentNode);
 
       currentNode.setIsOnClosedList(true);
       this.closedList.push(currentNode);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "astar-typescript",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "lodash": {
+    "lodash-es": {
       "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "typescript": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "run-example": "cd example && yarn install && yarn run dev"
   },
   "dependencies": {
-    "lodash": "4.17.15"
+    "lodash-es": "^4.17.15"
   },
   "devDependencies": {
     "typescript": "3.8.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "node",
     "declaration": true,
     "outDir": "./dist",
     "strict": false


### PR DESCRIPTION
Why?

When bundling this for browsers using webpack, the entire lodash library is bundled. By using lodash-es, only the specific functions are bundled. This allows tree-shaking to work and makes the library a better es-module.