### PR TITLE
[Feature] Node cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ this.aStarInstance = new AStarFinder({
 ```
 
 Set a maxCost for each grid node to enable using cost in the pathfinding calculation allowing you to make nodes less preferable.
-The example below would make nodes with 5 not walkable, and make the path finding prefer to avoid 2's
+
+> 0 = walkable
+> 2 = walkable but not prefered
+> 5 = not walkable
 
 ``` ts
 let myMatrix = [

--- a/README.md
+++ b/README.md
@@ -150,7 +150,30 @@ this.aStarInstance = new AStarFinder({
     width: 8,
     height: 8
   },
-  heuristicFunction: "Manhattan"
+  heuristic: "Manhattan"
+});
+```
+
+Set a maxCost for each grid node to enable using cost in the pathfinding calculation allowing you to make nodes less preferable.
+The example below would make nodes with 5 not walkable, and make the path finding prefer to avoid 2's
+
+``` ts
+let myMatrix = [
+  [0, 0, 2, 2, 2, 2, 0, 0],
+  [0, 0, 2, 2, 2, 2, 0, 5],
+  [0, 0, 5, 5, 0, 5, 5, 0],
+  [0, 0, 5, 0, 0, 0, 5, 0],
+  [0, 0, 0, 0, 0, 0, 5, 0],
+  [5, 5, 5, 0, 5, 0, 5, 0],
+  [0, 0, 0, 0, 5, 0, 5, 0],
+  [0, 0, 5, 0, 0, 0, 0, 0]
+];
+
+this.aStarInstance = new AStarFinder({
+  grid: {
+    matrix: myMatrix,
+    maxCost: 5,
+  }
 });
 ```
 

--- a/lib/core/grid.ts
+++ b/lib/core/grid.ts
@@ -6,6 +6,7 @@ export class Grid {
   readonly width: number;
   readonly height: number;
   readonly numberOfFields: number;
+  readonly maxCost: number;
 
   // The node grid
   private gridNodes: Node[][];
@@ -21,6 +22,8 @@ export class Grid {
       this.height = aParams.matrix.length;
       this.numberOfFields = this.width * this.height;
     }
+
+    this.maxCost = aParams.maxCost || 0;
 
     // Create and generate the matrix
     this.gridNodes = this.buildGridWithNodes(
@@ -85,10 +88,15 @@ export class Grid {
      */
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
-        if (matrix[y][x]) {
-          newGrid[y][x].setIsWalkable(false);
+        if (this.maxCost) {
+          newGrid[y][x].setIsWalkable(matrix[y][x] < this.maxCost);
+          newGrid[y][x].setCost(matrix[y][x]);
         } else {
-          newGrid[y][x].setIsWalkable(true);
+          if (matrix[y][x]) {
+            newGrid[y][x].setIsWalkable(false);
+          } else {
+            newGrid[y][x].setIsWalkable(true);
+          }
         }
       }
     }
@@ -198,7 +206,8 @@ export class Grid {
         cloneGrid[y][x] = new Node({
           id: id,
           position: { x: x, y: y },
-          walkable: this.gridNodes[y][x].getIsWalkable()
+          walkable: this.gridNodes[y][x].getIsWalkable(),
+          cost: this.gridNodes[y][x].getCost(),
         });
 
         id++;

--- a/lib/core/node.ts
+++ b/lib/core/node.ts
@@ -11,6 +11,7 @@ export class Node {
   private isOnClosedList: boolean;
   private isOnOpenList: boolean;
   private isWalkable: boolean;
+  private cost: number;
 
   constructor(aParams: INodeConstructor) {
     this.id = aParams.id;
@@ -23,6 +24,7 @@ export class Node {
     this.isOnClosedList = false;
     this.isOnOpenList = false;
     this.isWalkable = aParams.walkable || true;
+    this.cost = aParams.cost || 0;
   }
 
   /**
@@ -89,6 +91,10 @@ export class Node {
     return this.isWalkable;
   }
 
+  public getCost(): number {
+    return this.cost;
+  }
+
   /**
    * Setter functions
    */
@@ -106,5 +112,9 @@ export class Node {
 
   public setIsWalkable(isWalkable: boolean): void {
     this.isWalkable = isWalkable;
+  }
+
+  public setCost(cost: number): void {
+    this.cost = cost;
   }
 }

--- a/lib/finders/astar-finder.ts
+++ b/lib/finders/astar-finder.ts
@@ -31,7 +31,8 @@ export class AStarFinder {
       width: aParams.grid.width,
       height: aParams.grid.height,
       matrix: aParams.grid.matrix || undefined,
-      densityOfObstacles: aParams.grid.densityOfObstacles || 0
+      densityOfObstacles: aParams.grid.densityOfObstacles || 0,
+      maxCost: aParams.grid.maxCost || 0,
     });
 
     // Init lists
@@ -146,8 +147,9 @@ export class AStarFinder {
         // Calculate the g value of the neightbor
         const nextGValue =
           currentNode.getGValue() +
+          neightbor.getCost() +
           (neightbor.position.x !== currentNode.position.x ||
-          neightbor.position.y! == currentNode.position.y
+            neightbor.position.y! == currentNode.position.y
             ? this.weight
             : this.weight * 1.41421);
 

--- a/lib/interfaces/astar.interfaces.ts
+++ b/lib/interfaces/astar.interfaces.ts
@@ -14,12 +14,14 @@ export interface IGridConstructor {
   height?: number;
   matrix?: number[][];
   densityOfObstacles?: number;
+  maxCost?: number;
 }
 
 export interface INodeConstructor {
   id: number;
   position: IPoint;
   walkable?: boolean;
+  cost?: number;
 }
 
 export interface IPoint {


### PR DESCRIPTION
Whilst working on my own project i found i wanted to include a cost into node, so that the pathing would avoid them if possible.

So I have implemented it and will let you decide if you want it. (this also addresses issue #14)

I have implemented it so that it is non breaking, as it only enables if the developer sets a previously non existant option.


> 0 = walkable
> 2 = walkable but not prefered
> 5 = not walkable

``` ts
let myMatrix = [
  [0, 0, 2, 2, 2, 2, 0, 0],
  [0, 0, 2, 2, 2, 2, 0, 5],
  [0, 0, 5, 5, 0, 5, 5, 0],
  [0, 0, 5, 0, 0, 0, 5, 0],
  [0, 0, 0, 0, 0, 0, 5, 0],
  [5, 5, 5, 0, 5, 0, 5, 0],
  [0, 0, 0, 0, 5, 0, 5, 0],
  [0, 0, 5, 0, 0, 0, 0, 0]
];

this.aStarInstance = new AStarFinder({
  grid: {
    matrix: myMatrix,
    maxCost: 5,
  }
});
```


Examples:

I wanted the wires to avoid blocking the pins on the chips if possible to make it easier for later wire to path to them.

![2020-08-24_00-45-35_firefox](https://user-images.githubusercontent.com/44343744/90992135-a6dbab00-e5a5-11ea-8f56-de41c0092e22.png)

So with my cost feature i added an extra cost to the nodes just above and below a chip. now it paths like this.

![2020-08-24_00-44-50_firefox](https://user-images.githubusercontent.com/44343744/90992165-c96dc400-e5a5-11ea-9863-63bda77fb83f.png)

But if it MUST go into a space because going around is impossible or far too costly it will

![2020-08-24_00-46-04_firefox](https://user-images.githubusercontent.com/44343744/90992212-0cc83280-e5a6-11ea-96ba-e9e8cff9a10d.png)

Developers using the feature can set their own cost values to make things even les desirable if they wished, this could for instance be used in a game to avoid different types of terrain if possible, unless the path arround is far too long.