### PR TITLE
feat: remove lodash

### DIFF
--- a/lib/finders/astar-finder.ts
+++ b/lib/finders/astar-finder.ts
@@ -1,5 +1,3 @@
-import { minBy, remove } from 'lodash';
-
 import { backtrace } from '../core/util';
 import { calculateHeuristic } from '../core/heuristic';
 import { Grid } from '../core/grid';
@@ -112,13 +110,13 @@ export class AStarFinder {
     // As long the open list is not empty, continue searching a path
     while (this.openList.length !== 0) {
       // Get node with lowest f value
-      const currentNode = minBy(this.openList, (o) => {
-        return o.getFValue();
+      const currentNode = this.openList.reduce((prev, curr) => {
+        return prev.getFValue() < curr.getFValue() ? prev : curr;
       });
 
       // Move current node from open list to closed list
       currentNode.setIsOnOpenList(false);
-      remove(this.openList, currentNode);
+      this.openList = this.openList.filter(node => node !== currentNode);
 
       currentNode.setIsOnClosedList(true);
       this.closedList.push(currentNode);

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "build": "tsc",
     "run-example": "cd example && yarn install && yarn run dev"
   },
-  "dependencies": {
-    "lodash": "4.17.21"
-  },
   "devDependencies": {
     "typescript": "4.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,7 @@
 # yarn lockfile v1
 
 
-lodash@4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 typescript@4.1.3:
   version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==


### PR DESCRIPTION
I understand a recent version of this package did selective imports of lodash, but it still seems to include the full version of lodash. 

This can be validated on Bundlephobia https://bundlephobia.com/package/astar-typescript@1.2.5

With a few simple inline functions we can completely remove the need for lodash, changing the size of this library from ~75k to 4kb. 




